### PR TITLE
feat: Add --clean argument to clear output_img directory

### DIFF
--- a/dynamic.py
+++ b/dynamic.py
@@ -325,13 +325,6 @@ INTERVAL_LONG = '60m'
 
 # --- 執行主程式 (Run Main Program) ---
 if __name__ == "__main__":
-    # remove all the .png files in output_img folder
-    import os
-    import glob
-    files = glob.glob('output_img/*.png')
-    # for f in files:
-    #     os.remove(f)
-        
     plt.ioff()
     # --- 1. 設定命令列參數解析 ---
     parser = argparse.ArgumentParser(
@@ -360,10 +353,26 @@ if __name__ == "__main__":
         action="store_true",
         help="僅在價值期望值 (Expected Return) > 0 時才儲存圖表。"
     )
+    parser.add_argument(
+        "--clean",
+        action="store_true",
+        help="在執行分析前，清除 output_img/ 資料夾中的所有 .png 檔案 (Clear all .png files in output_img/ before execution)."
+    )
     # (未來也可以在這裡新增 --tickers 或 --hours 參數)
     args = parser.parse_args()
 
-   
+    if args.clean:
+        print("Cleaning output_img/ directory...")
+        # 確保 os 和 glob 已經在檔案頂部匯入
+        files = glob.glob('output_img/*.png')
+        count = 0
+        for f in files:
+            try:
+                os.remove(f)
+                count += 1
+            except OSError as e:
+                print(f"Error removing file {f}: {e}")
+        print(f"Removed {count} .png file(s) from output_img/.")
 
     # --- 動態日期計算 (Dynamic Date Calculation) ---
     max_lookback_hours = args.base_hours * args.iterations


### PR DESCRIPTION
This commit introduces a new command-line argument `--clean` to the `dynamic.py` script.

When the script is executed with the `--clean` flag, it will now automatically delete all files with a `.png` extension from the `output_img/` directory before any data processing or analysis begins.

This feature helps users start with a clean output directory for each run, preventing the accumulation of old plot images.

The implementation includes:
- Addition of the `--clean` argument using `argparse`.
- Logic to perform the file deletion when the flag is present.
- User-facing messages to indicate that the directory is being cleaned and to report the number of files removed.
- Removal of an old, commented-out block of code that was previously intended for the same purpose.