### PR TITLE
feat: Save summary report to output_txt directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ wheels/
 .venv
 *.png
 .DS_Store
+output_txt/


### PR DESCRIPTION
The script now saves the summary report to a file in the `output_txt` directory.

Key changes:
- The `dynamic.py` script now creates the `output_txt` directory if it does not exist.
- A summary report file (`summary_report.txt`) is created and a header is written at the start of the execution.
- The summary report content is appended to the file during the analysis.
- The `--clean` argument is updated to also remove files from `output_txt`.
- The `output_txt/` directory is added to `.gitignore`.