### PR TITLE
feat: Add functionality to save data as CSV files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ wheels/
 *.png
 .DS_Store
 output_txt/*.txt
+output_data/


### PR DESCRIPTION
This commit introduces a new feature to the `dynamic.py` script that allows saving the raw downloaded stock data and the analysis results to CSV files.

Key changes:
- Added a `--save-data` command-line argument to enable this feature.
- Created a new `output_data/` directory to store the CSV files.
- Updated the `--clean` logic to also remove files from the `output_data/` directory.
- Added `output_data/` to the `.gitignore` file.
- Implemented the logic to save the raw and analyzed dataframes to CSV files in the `run_analysis_loops` function.