### PR TITLE
feat: Support `--start-date` and `--end-date` for absolute time range…

### DIFF
--- a/run.py
+++ b/run.py
@@ -240,10 +240,30 @@ def main():
     # Dynamic Date Calculation
     max_lookback_hours = args.base_hours * args.iterations
     max_lookback_timedelta = pd.Timedelta(hours=max_lookback_hours)
-    analysis_period_timedelta = pd.Timedelta(args.period)
-    total_download_timedelta = max_lookback_timedelta + analysis_period_timedelta
-    end_date = pd.Timestamp.now()
-    start_date = end_date - total_download_timedelta
+
+    if args.start_date and args.end_date:
+        # --- 模式 1：絕對日期 (Absolute Date Mode) ---
+        print(f"模式：使用絕對日期區間 (Mode: Using absolute date range)")
+        analysis_start_date = pd.Timestamp(args.start_date)
+        analysis_end_date = pd.Timestamp(args.end_date)
+
+        # 下載的開始日期需要包含回測所需的時間
+        start_date = analysis_start_date - max_lookback_timedelta
+        end_date = analysis_end_date
+
+        # 用於日誌記錄的週期字串
+        period_log_str = f"{args.start_date} to {args.end_date}"
+
+    else:
+        # --- 模式 2：相對日期 (Relative Date Mode - Current Logic) ---
+        print(f"模式：使用相對期間 (Mode: Using relative period '{args.period}')")
+        analysis_period_timedelta = pd.Timedelta(args.period)
+        total_download_timedelta = max_lookback_timedelta + analysis_period_timedelta
+        end_date = pd.Timestamp.now()
+        start_date = end_date - total_download_timedelta
+
+        # 用於日誌記錄的週期字串
+        period_log_str = args.period
 
     # 定義報告檔案路徑 (Define report file path) with base hours
     summary_filename = f"output_txt/summary_report_{args.base_hours}_{args.prepost_short}.txt"
@@ -266,7 +286,7 @@ def main():
 
     # Use the global TICKER_SYMBOLS for the download
     data_short, data_long = download_stock_data(
-        TICKER_SYMBOLS, args.interval_short, INTERVAL_LONG, start_date, end_date, args.period, args
+        TICKER_SYMBOLS, args.interval_short, INTERVAL_LONG, start_date, end_date, period_log_str, args
     )
 
     all_data, all_results = run_analysis_loops(

--- a/src/stock_analysis/cli.py
+++ b/src/stock_analysis/cli.py
@@ -57,4 +57,16 @@ def setup_arg_parser():
         action='store_true',
         help='儲存下載的原始 K 線資料與分析後的 DataFrame 為 CSV 檔案。'
     )
+    parser.add_argument(
+        '--start-date',
+        type=str,
+        default=None,
+        help='指定分析的開始日期 (格式: YYYY-MM-DD)。若提供此參數，將忽略 --period。'
+    )
+    parser.add_argument(
+        '--end-date',
+        type=str,
+        default=None,
+        help='指定分析的結束日期 (格式: YYYY-MM-DD)。若提供此參數，將忽略 --period。'
+    )
     return parser

--- a/src/stock_analysis/data.py
+++ b/src/stock_analysis/data.py
@@ -3,7 +3,7 @@ import pytz
 import argparse
 import pandas as pd
 
-def download_stock_data(tickers: list, interval_short: str, interval_long: str, start_date, end_date, period: str, args: argparse.Namespace):
+def download_stock_data(tickers: list, interval_short: str, interval_long: str, start_date, end_date, period_log_str: str, args: argparse.Namespace):
     """
     Downloads stock data for the given tickers and intervals, and handles timezone conversion.
     """
@@ -11,7 +11,7 @@ def download_stock_data(tickers: list, interval_short: str, interval_long: str, 
     print(f"======= 開始批次下載資料 (Starting Batch Download) =======")
     print(f"Tickers: {tickers}")
     print(f"Intervals: {interval_short}, {interval_long}")
-    print(f"Period: {period}")
+    print(f"Analysis Period/Range: {period_log_str}")
     print(f"Pre/Post Market (Short): {args.prepost_short}")
     print(f"Pre/Post Market (Long): {args.prepost_long}")
     print("=======================================================\n")


### PR DESCRIPTION
… analysis

This commit introduces the functionality for users to specify an absolute, fixed date range for the stock analysis by using the `--start-date` and `--end-date` command-line arguments.

Key changes include:
- Added `--start-date` and `--end-date` optional arguments to `src/stock_analysis/cli.py`.
- Updated `run.py` to prioritize the absolute date range over the relative `--period` if provided. The script now calculates the required download period to accommodate the analysis and lookback window.
- Renamed a parameter in `src/stock_analysis/data.py` from `period` to `period_log_str` for better code clarity, ensuring the logging reflects the correct analysis range (either relative or absolute).

If `--start-date` and `--end-date` are not provided, the script falls back to the existing relative period logic, ensuring backward compatibility.