### PR TITLE
feat: Add trailing stop backtest mode

### DIFF
--- a/src/stock_analysis/cli.py
+++ b/src/stock_analysis/cli.py
@@ -69,4 +69,30 @@ def setup_arg_parser():
         default=None,
         help='指定分析的結束日期 (格式: YYYY-MM-DD)。若提供此參數，將忽略 --period。'
     )
+
+    # --- Strategy Backtest Arguments ---
+    parser.add_argument(
+        '--strategy-backtest',
+        action='store_true',
+        help='啟用追蹤停損策略回測模式 (Enable the trailing stop strategy backtest mode).'
+    )
+    parser.add_argument(
+        '--entry-trail-pct',
+        type=float,
+        default=5.0,
+        help='追蹤停損買單的百分比 (Trailing percentage for the entry order).'
+    )
+    parser.add_argument(
+        '--exit-trail-pct',
+        type=float,
+        default=3.0,
+        help='追蹤停損賣單的百分比 (Trailing percentage for the exit order).'
+    )
+    parser.add_argument(
+        '--shares',
+        type=int,
+        default=100,
+        help='交易股數 (Number of shares to trade).'
+    )
+
     return parser

--- a/src/stock_analysis/core.py
+++ b/src/stock_analysis/core.py
@@ -71,3 +71,73 @@ def analyze_fixed_time_lag(stock_data: pd.DataFrame, ticker: str, interval: str,
     }
 
     return results, analysis_df
+
+import argparse
+
+def run_strategy_backtest(stock_data: pd.DataFrame, ticker: str, args: argparse.Namespace):
+    """
+    Simulates a trailing stop trading strategy.
+    """
+    if stock_data.empty:
+        print(f"No data for {ticker}, skipping backtest.")
+        return None
+
+    # --- State Machine Initialization ---
+    state = 'LOOKING_TO_BUY'
+    lowest_price_seen = float('inf')
+    highest_price_since_buy = float('-inf')
+    buy_price = 0
+    sell_price = 0
+    buy_time = None
+    sell_time = None
+
+    # --- Iterate through K-lines ---
+    for index, row in stock_data.iterrows():
+        current_low = row['Low']
+        current_high = row['High']
+
+        if state == 'LOOKING_TO_BUY':
+            if current_low < lowest_price_seen:
+                lowest_price_seen = current_low
+
+            buy_trigger_price = lowest_price_seen * (1 + args.entry_trail_pct / 100)
+
+            if current_high >= buy_trigger_price:
+                buy_price = buy_trigger_price
+                buy_time = index
+                highest_price_since_buy = buy_price
+                state = 'IN_POSITION'
+                print(f"[{ticker}] BUY triggered at ${buy_price:.2f} on {buy_time}")
+
+
+        elif state == 'IN_POSITION':
+            if current_high > highest_price_since_buy:
+                highest_price_since_buy = current_high
+
+            sell_trigger_price = highest_price_since_buy * (1 - args.exit_trail_pct / 100)
+
+            if current_low <= sell_trigger_price:
+                sell_price = sell_trigger_price
+                sell_time = index
+                state = 'FINISHED'
+                print(f"[{ticker}] SELL triggered at ${sell_price:.2f} on {sell_time}")
+                break # Exit after the first full trade
+
+    # --- Result Compilation ---
+    if buy_price > 0 and sell_price > 0:
+        pnl = (sell_price - buy_price) * args.shares
+        result = {
+            'ticker': ticker,
+            'buy_price': buy_price,
+            'buy_time': buy_time,
+            'sell_price': sell_price,
+            'sell_time': sell_time,
+            'shares': args.shares,
+            'profit_and_loss': pnl,
+            'entry_trail_pct': args.entry_trail_pct,
+            'exit_trail_pct': args.exit_trail_pct
+        }
+        return result
+    else:
+        print(f"[{ticker}] No complete trade was executed during the backtest period.")
+        return None


### PR DESCRIPTION
This commit introduces a new strategy backtest mode to the application, simulating a trailing stop buy/sell strategy.

Key changes:
- Added CLI arguments: `--strategy-backtest`, `--entry-trail-pct`, `--exit-trail-pct`, `--shares`.
- Implemented `run_strategy_backtest` function in `core.py` with the state machine logic.
- Integrated the new backtest mode into `run.py`, which is triggered by the `--strategy-backtest` flag.
- The backtest mode prints a detailed report for the first completed trade for each ticker.