### PR TITLE
feat: Add profit percentage and budget-based trading to backtest

### DIFF
--- a/run.py
+++ b/run.py
@@ -208,11 +208,20 @@ def run_backtest_mode(ticker_list_array: list, data_short: dict, args: argparse.
             if result:
                 print(f"\n======= 回測報告: {result['ticker']} =======")
                 print(f"策略: {result['entry_trail_pct']}% 進場追蹤, {result['exit_trail_pct']}% 出場追蹤")
-                print(f"部位: {result['shares']} 股")
+
+                # --- NEW: Conditional print for Budget vs Shares ---
+                if result['budget']:
+                    print(f"預算 (Budget): ${result['budget']:.2f}")
+                    print(f"部位 (Shares): {result['shares']} 股 (基於預算計算)")
+                else:
+                    print(f"部位 (Shares): {result['shares']} 股 (固定)")
+                # --- END NEW ---
+
                 print(f"買入觸發: ${result['buy_price']:.2f} (於 {result['buy_time'].strftime('%Y-%m-%d %H:%M')})")
                 print(f"賣出觸發: ${result['sell_price']:.2f} (於 {result['sell_time'].strftime('%Y-%m-%d %H:%M')})")
                 print("----------------------------------------")
                 print(f"每股獲利: ${result['sell_price'] - result['buy_price']:.2f}")
+                print(f"每股獲利率 (Profit %): {result['profit_pct']:.2%}") # <-- Add this line
                 print(f"總損益: ${result['profit_and_loss']:.2f}")
                 print("======================================\n")
 

--- a/src/stock_analysis/cli.py
+++ b/src/stock_analysis/cli.py
@@ -94,5 +94,11 @@ def setup_arg_parser():
         default=100,
         help='交易股數 (Number of shares to trade).'
     )
+    parser.add_argument(
+        '--budget',
+        type=float,
+        default=None,
+        help='指定回測的總預算 (美元)。若提供此參數，將忽略 --shares。 (Total budget in USD. If provided, --shares is ignored.)'
+    )
 
     return parser

--- a/src/stock_analysis/core.py
+++ b/src/stock_analysis/core.py
@@ -125,17 +125,29 @@ def run_strategy_backtest(stock_data: pd.DataFrame, ticker: str, args: argparse.
 
     # --- Result Compilation ---
     if buy_price > 0 and sell_price > 0:
-        pnl = (sell_price - buy_price) * args.shares
+
+        # --- NEW: Calculate shares_to_trade ---
+        if args.budget:
+            shares_to_trade = args.budget // buy_price # Use floor division for whole shares
+        else:
+            shares_to_trade = args.shares
+        # --- END NEW ---
+
+        pnl = (sell_price - buy_price) * shares_to_trade # Use shares_to_trade
+        profit_pct = (sell_price - buy_price) / buy_price # From Part 1
+
         result = {
             'ticker': ticker,
             'buy_price': buy_price,
             'buy_time': buy_time,
             'sell_price': sell_price,
             'sell_time': sell_time,
-            'shares': args.shares,
+            'shares': shares_to_trade, # Store the calculated shares
             'profit_and_loss': pnl,
+            'profit_pct': profit_pct,
             'entry_trail_pct': args.entry_trail_pct,
-            'exit_trail_pct': args.exit_trail_pct
+            'exit_trail_pct': args.exit_trail_pct,
+            'budget': args.budget # Store budget info
         }
         return result
     else:


### PR DESCRIPTION
This commit enhances the `--strategy-backtest` mode with two new features:

1.  **Profit Percentage Reporting:** The backtest report now includes the profit per share as a percentage, in addition to the absolute dollar value.

2.  **Budget-Based Trading:** A new `--budget` command-line argument allows users to specify a total budget for a trade. If provided, the number of shares is calculated based on the entry price, ignoring the `--shares` argument. The report is updated to clarify whether a budget or a fixed share count was used.