### PR TITLE
Refactor: Limit strategy backtest to one trade per day

### DIFF
--- a/src/stock_analysis/core.py
+++ b/src/stock_analysis/core.py
@@ -90,6 +90,7 @@ def run_strategy_backtest(stock_data: pd.DataFrame, ticker: str, args: argparse.
     buy_price = 0
     buy_time = None
     current_day = None
+    day_of_last_trade = None
 
     # --- Iterate through K-lines ---
     for index, row in stock_data.iterrows():
@@ -98,6 +99,9 @@ def run_strategy_backtest(stock_data: pd.DataFrame, ticker: str, args: argparse.
         bar_date = index.date()
 
         if state == 'LOOKING_TO_BUY':
+            if bar_date == day_of_last_trade:
+                continue
+
             # --- Daily Reset Logic ---
             if args.daily_trades and bar_date != current_day:
                 current_day = bar_date
@@ -154,6 +158,7 @@ def run_strategy_backtest(stock_data: pd.DataFrame, ticker: str, args: argparse.
                 trades.append(result)
 
                 # --- Reset for next trade ---
+                day_of_last_trade = bar_date
                 state = 'LOOKING_TO_BUY'
                 lowest_price_seen = current_low # Start tracking from current bar's low
                 highest_price_since_buy = float('-inf')


### PR DESCRIPTION
This commit modifies the `run_strategy_backtest` function in `src/stock_analysis/core.py` to ensure that a maximum of one "buy -> sell" trade is completed per day.

Previously, the state would reset to `LOOKING_TO_BUY` immediately after a sell, allowing for multiple trades within the same day.

This change introduces a `day_of_last_trade` variable. When a trade is sold, the date is recorded. The buying logic now checks this variable and skips any new buy triggers for the remainder of that day. This ensures that the backtest adheres to the "one trade per day" rule.