### PR TITLE
Feat: Add `--time-anchor` parameter

### DIFF
--- a/run.py
+++ b/run.py
@@ -90,7 +90,8 @@ def run_analysis_loops(ticker_list_array: list, data_short_batch, data_long_batc
                     stock_data=stock_data_to_analyze,
                     ticker=ticker_symbol,
                     interval=interval_short,
-                    holding_hours=holding_hours
+                    holding_hours=holding_hours,
+                    time_anchor=args.time_anchor
                 )
 
                 if analysis_results and detailed_df is not None and not detailed_df.empty:

--- a/src/stock_analysis/cli.py
+++ b/src/stock_analysis/cli.py
@@ -69,6 +69,13 @@ def setup_arg_parser():
         default=None,
         help='指定分析的結束日期 (格式: YYYY-MM-DD)。若提供此參數，將忽略 --period。'
     )
+    parser.add_argument(
+        '--time-anchor',
+        type=str,
+        default='start',
+        choices=['start', 'end'],
+        help="Set the time anchor for analysis: 'start' (X-axis is buy time) or 'end' (X-axis is sell time)."
+    )
 
     # --- Strategy Backtest Arguments ---
     parser.add_argument(

--- a/src/stock_analysis/core.py
+++ b/src/stock_analysis/core.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import re
 
-def analyze_fixed_time_lag(stock_data: pd.DataFrame, ticker: str, interval: str, holding_hours: float):
+def analyze_fixed_time_lag(stock_data: pd.DataFrame, ticker: str, interval: str, holding_hours: float, time_anchor: str = 'start'):
     """
     分析一檔股票在給定數據下，與 {holding_hours} 小時前的 K 線收盤價的價差。
     Analyzes the price difference of a stock based on provided data,
@@ -41,8 +41,12 @@ def analyze_fixed_time_lag(stock_data: pd.DataFrame, ticker: str, interval: str,
     # print("-" * 30)
 
     # --- 核心計算 (Core Calculation) ---
-    stock_data['P_buy'] = stock_data['Close']
-    stock_data['P_sell'] = stock_data['Close'].shift(-lag_periods)
+    if time_anchor == 'end':
+        stock_data['P_buy'] = stock_data['Close'].shift(lag_periods)
+        stock_data['P_sell'] = stock_data['Close']
+    else:  # Default to 'start'
+        stock_data['P_buy'] = stock_data['Close']
+        stock_data['P_sell'] = stock_data['Close'].shift(-lag_periods)
 
     analysis_df = stock_data.dropna().copy()
 


### PR DESCRIPTION
This commit introduces the `--time-anchor` command-line parameter to control the time-lag analysis logic.

The parameter can be set to 'start' (default) for forward-looking analysis or 'end' for backward-looking analysis. This allows users to analyze performance based on either the buy time or the sell time.