### PR TITLE
Feat: Add `--tickers` argument for ad-hoc analysis

### DIFF
--- a/run.py
+++ b/run.py
@@ -319,7 +319,18 @@ def main():
 
 
     # Import configurations
-    from src.stock_analysis.config import TICKER_SYMBOLS, TICKER_LIST_ARRAY, INTERVAL_LONG
+    from src.stock_analysis.config import INTERVAL_LONG
+
+    # --- Ticker Configuration ---
+    # Check if the --tickers argument is provided. If so, override the config.
+    if args.tickers:
+        print(f"模式：使用命令行提供的 Tickers (Mode: Using tickers from command line): {args.tickers}")
+        TICKER_SYMBOLS = args.tickers
+        TICKER_LIST_ARRAY = [args.tickers]  # Analyze all provided tickers as a single group
+    else:
+        print("模式：使用設定檔中的 Tickers (Mode: Using tickers from config file)")
+        from src.stock_analysis.config import TICKER_SYMBOLS, TICKER_LIST_ARRAY
+
 
     # Use the global TICKER_SYMBOLS for the download
     data_short, data_long = download_stock_data(

--- a/src/stock_analysis/cli.py
+++ b/src/stock_analysis/cli.py
@@ -8,6 +8,12 @@ def setup_arg_parser():
         description="執行 stock-dynamic 分析，可自訂分析週期。"
     )
     parser.add_argument(
+        "-t", "--tickers",
+        nargs='+',
+        default=None,
+        help="Specify one or more ticker symbols to analyze, overriding the config file."
+    )
+    parser.add_argument(
         "-p", "--period",
         type=str,
         default="5d",


### PR DESCRIPTION
This commit introduces a new command-line argument, `--tickers` (or `-t`), which allows the user to specify a list of ticker symbols to analyze directly from the command line.

When the `--tickers` argument is provided, the script will override the `TICKER_SYMBOLS` and `TICKER_LIST_ARRAY` that are normally imported from `src/stock_analysis/config.py`. This provides a convenient way to run ad-hoc analyses without modifying the configuration file.

Changes include:
- Added the `--tickers` argument to `src/stock_analysis/cli.py`.
- Modified `run.py` to conditionally use the command-line tickers or fall back to the config file.