### PR TITLE
feat: Add GitHub Action for linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,24 @@
+name: Lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9.19'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Lint with ruff
+      run: |
+        ruff check .


### PR DESCRIPTION
This commit introduces a new GitHub Action workflow to automate linting using `ruff`.

The workflow is defined in `.github/workflows/lint.yml` and is triggered on every push and pull request to the `main` branch. It ensures that all code contributions are checked for linting errors, helping to maintain code quality and consistency across the project.